### PR TITLE
MT35501 : remove warning uninitialized value in split

### DIFF
--- a/Koha/Plugin/Com/Biblibre/PatronImport/Helper/Config.pm
+++ b/Koha/Plugin/Com/Biblibre/PatronImport/Helper/Config.pm
@@ -156,7 +156,9 @@ sub _load_setup {
     $sth->execute($import_id);
 
     my $values = $sth->fetchrow_hashref;
-    my @plugins_enabled = split(',', $values->{plugins_enabled});
+
+    my $plugins_enabled_value = $values->{plugins_enabled} // '';
+    my @plugins_enabled = split(',', $plugins_enabled_value);
     $values->{plugins_enabled} = {};
     foreach my $plugin ( @plugins_enabled ) {
         $values->{plugins_enabled}{$plugin} = 1;


### PR DESCRIPTION
Fix warning uninitialized value in split occuring when no plugin (of this plugin)